### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ Yes, ofcourse.
 Why not ``namedtuple``?
 ------------------------
 
-It's ugly, repetivive and unflexible. Compare this:
+It's ugly, repetitive and inflexible. Compare this:
 
 .. code:: python
 
@@ -342,7 +342,7 @@ Worth noting:
 All in all, attrs_ is a fast and minimal container library that does support subclasses, 
 but quite differently than ``fields``. Definitely worth considering. 
 
-Also, nowdays it has more features than ``fields``. See `#6 <https://github.com/ionelmc/python-fields/issues/6>`_.  
+Also, nowadays it has more features than ``fields``. See `#6 <https://github.com/ionelmc/python-fields/issues/6>`_.  
 
 .. _attrs: https://pypi.python.org/pypi/attrs
 
@@ -375,7 +375,7 @@ Testimonials
 
 ..
 
-    Fields is completey bat-shit insane, but kind of cool.
+    Fields is completely bat-shit insane, but kind of cool.
     
     -- Someone on IRC (#python)
 

--- a/src/fields/__init__.py
+++ b/src/fields/__init__.py
@@ -5,7 +5,7 @@ How it works: the library is composed of 2 major parts:
   and default values).
 * The `factory`. A metaclass that implements attribute/item access, so you can do ``Fields.a.b.c``. On each
   getattr/getitem it returns a new instance with the new state. Its ``__new__`` method takes extra arguments to store
-  the contruction state and it works in two ways:
+  the construction state and it works in two ways:
 
   * Construction phase (there are no bases). Make new instances of the `Factory` with new state.
   * Usage phase. When subclassed (there are bases) it will use the sealer to return the final class.

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -258,7 +258,7 @@ def test_unequal_same_class(CmpC):
 
 def test_unequal_different_class(CmpC):
     """
-    Unequal objects of differnt type are detected even if their attributes
+    Unequal objects of different type are detected even if their attributes
     match.
     """
     class NotCmpC(object):


### PR DESCRIPTION
There are small typos in:
- README.rst
- src/fields/__init__.py
- tests/test_fields.py

Fixes:
- Should read `repetitive` rather than `repetivive`.
- Should read `nowadays` rather than `nowdays`.
- Should read `inflexible` rather than `unflexible`.
- Should read `different` rather than `differnt`.
- Should read `construction` rather than `contruction`.
- Should read `completely` rather than `completey`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md